### PR TITLE
chore: get bazel data as a submodule

### DIFF
--- a/.github/workflows/codegen.yml
+++ b/.github/workflows/codegen.yml
@@ -1,0 +1,30 @@
+# This workflow is used to generate docs from the Bazel repo
+name: Generate docs from Bazel repo
+on:
+    push:
+        branches:
+          - 'main'
+    workflow_dispatch:
+        inputs:
+            bazelCommitHash:
+                description: 'The commit hash of the Bazel repo to use'
+                type: string
+                default: origin/main
+    workflow_call:
+        inputs:
+            bazelCommitHash:
+                description: 'The commit hash of the Bazel repo to use'
+                type: string
+                default: origin/main
+     
+jobs:
+    codegen:
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@v5
+            - name: Checkout submodules
+              run: git submodule update --init -- upstream
+            
+            - name: Checkout commit of BCR submodule
+              working-directory: upstream
+              run: git checkout ${{ inputs.bcrCommitHash }}

--- a/.github/workflows/trigger-from-bazel-repo.yml
+++ b/.github/workflows/trigger-from-bazel-repo.yml
@@ -1,0 +1,9 @@
+on:
+  repository_dispatch:
+    types: [on-bazel-trigger]
+jobs:
+  deploy:
+    uses: ./.github/workflows/codegen.yml
+    with:
+      bcrCommitHash: ${{ github.event.client_payload.bcrCommitHash }}
+      secrets: inherit

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "upstream"]
+	path = upstream
+	url = https://github.com/bazelbuild/bazel.git

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Bazel Docs
 
-Convert Bazel’s Devsite docs into a Hugo/Docsy site for easy modification.
+Host Bazel’s Devsite docs on a Mintlify site for easy modification.
 
 ## Motivation
 
@@ -8,59 +8,22 @@ This tool implements the improvements outlined in [Bazel Docs: Why It Might Be T
 
 ## Live Demo
 
-https\://bazel-docs-68tmf.ondigitalocean.app/
+https://bazel.online
 
 ## How it works
 
-1. Clones the Devsite source from `bazel.build/docs`.
-2. Transforms Devsite frontmatter and directory layout into Hugo/Docsy format.
-3. Converts CSS/SCSS for Docsy theme compatibility.
+1. Clones the Devsite source from `bazel.build/docs` using a git submodule
+2. Transforms Devsite frontmatter and directory layout into MDX format.
+3. Hosted on Mintlify
 
 ## Usage
 
-Bash into the docker image to see the Hugo converted website:
+Clone the submodule: `git submodule update --init -- upstream`
 
-```bash
-docker run -it -p 1313:1313 alan707/bazel-docs:latest bash
-```
+Run the converter tool: TODO
 
-Once inside, the generated Hugo site will be at the following location:
+Install the Mintlify dev tool: `npm install -g mint`
 
-```bash
-root@7feab7b056d2:/app/docs# ls -al /app/docs
-total 52
-drwxr-xr-x  1 root root 4096 Jul 15 05:53 .
-drwxr-xr-x  1 root root 4096 Jul 15 05:53 ..
--rw-r--r--  1 root root    0 Jul 15 05:53 .hugo_build.lock
-drwxr-xr-x  2 root root 4096 Jul 15 05:53 archetypes
-drwxr-xr-x  3 root root 4096 Jul 15 05:53 assets
-drwxr-xr-x 25 root root 4096 Jul 15 05:53 content
-drwxr-xr-x  2 root root 4096 Jul 15 05:53 data
--rw-r--r--  1 root root   99 Jul 15 05:53 go.mod
--rw-r--r--  1 root root  394 Jul 15 05:53 go.sum
--rw-r--r--  1 root root 2527 Jul 15 05:53 hugo.yaml
-drwxr-xr-x  2 root root 4096 Jul 15 05:53 i18n
-drwxr-xr-x  2 root root 4096 Jul 15 05:53 layouts
-drwxr-xr-x  3 root root 4096 Jul 15 05:53 resources
-drwxr-xr-x 12 root root 4096 Jul 15 05:53 static
-```
+Then run `mint dev` to get a locally-running site.
 
-To test your changes, you can convert the Bazel Docs Devsite into a Hugo website running this command
-```bash
-root@7feab7b056d2:/app# python /app/cli.py convert --source /app/work/bazel-source/site/en/ --output /app/docs/
-```
-
-Add the modules needed (mainly Docsy)
-```bash
-cd /app/docs
-hugo mod init github.com/alan707/bazel-docs && \
-    hugo mod get github.com/google/docsy@v0.12.0 && \
-    hugo mod tidy
-```
-
-Generate static files and start the Hugo server
-```bash
-cd /app/docs
-hugo --destination /workspace/public
-hugo server --bind 0.0.0.0 --baseURL "http://localhost:1313"
-```
+Send a PR to get a hosted preview of the changes.


### PR DESCRIPTION
This is the easiest way to just add a 'pointer' to get a read-only copy of their tree locally